### PR TITLE
Add two Raycast extension under the Tools category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,5 +274,5 @@ A Open Source Projects
 - [City Ecommerce UI Kit](https://github.com/shopifypartners/City-Ecommerce-UI-Kit) - City is our free ecommerce UI kit based on a fictional fashion apparel shop. (Prototyping Shopify Store design)
 
 ### Raycast Extension
-- [Search Shopify Liquid Documentation](https://www.raycast.com/maximedaraize/search-shopify-liquid-documentation) - Raycast extension to preview and access Shopify documentation
-- [Shopify Developer Changelog](https://www.raycast.com/sandypockets/shopify-developer-changelog) - Raycast extension listing the Shopify changlog
+- [Search Shopify Liquid Documentation](https://www.raycast.com/maximedaraize/search-shopify-liquid-documentation) - Raycast extension to preview and access Shopify documentation.
+- [Shopify Developer Changelog](https://www.raycast.com/sandypockets/shopify-developer-changelog) - Raycast extension listing the Shopify changlog.

--- a/readme.md
+++ b/readme.md
@@ -272,3 +272,7 @@ A Open Source Projects
 - [Shopify Product CSVs and Images](https://github.com/shopifypartners/shopify-product-csvs-and-images) - Get your Shopify development stores started with great product data.
 - [Sketch Shopify Data Populator](https://github.com/shopifypartners/sketch-shopify-data-populator) - A Sketch App plugin to populate your designs with meaningful ecommerce data.
 - [City Ecommerce UI Kit](https://github.com/shopifypartners/City-Ecommerce-UI-Kit) - City is our free ecommerce UI kit based on a fictional fashion apparel shop. (Prototyping Shopify Store design)
+
+### Raycast Extension
+- [Search Shopify Liquid Documentation](https://www.raycast.com/maximedaraize/search-shopify-liquid-documentation) - Raycast extension to preview and access Shopify documentation
+- [Shopify Developer Changelog](https://www.raycast.com/sandypockets/shopify-developer-changelog) - Raycast extension listing the Shopify changlog


### PR DESCRIPTION
## Description

I have added two [Raycast](https://www.raycast.com/) extension at the bottom of the Tools category.

- Added the subcategory (Raycast Extension)

### [Search Shopify Liquid Documentation](https://www.raycast.com/maximedaraize/search-shopify-liquid-documentation)

This extension let you preview each element of the shopify (liquid) documentation. Description, code snippet, deprecated tag, object properties and more directly in raycast. 
![image](https://github.com/julionc/awesome-shopify/assets/37809938/34805b07-3c13-42a6-9d03-311e9349287a)
![image](https://github.com/julionc/awesome-shopify/assets/37809938/d3e2e95a-e6ab-4ed4-85ff-447b4a24525c)
![image](https://github.com/julionc/awesome-shopify/assets/37809938/9edc4ae8-0184-4052-95c0-06fc200c8452)
![image](https://github.com/julionc/awesome-shopify/assets/37809938/01edabc9-8ccc-48cd-945c-708eec6a9496)
 
 ### [Shopify Developer Changelog](https://www.raycast.com/sandypockets/shopify-developer-changelog)
 
 This extension display the latest changelog directly in raycast.
 
![image](https://github.com/julionc/awesome-shopify/assets/37809938/053b3eed-6fb0-4663-8401-5af30b04cdaa)
![image](https://github.com/julionc/awesome-shopify/assets/37809938/c26f0d5c-34c4-42af-94ee-813f8efe106d)
