### PR TITLE
Add PROPS! - Copy Custom Shopify Sections in 1 Click

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,7 @@ You can use official Shopify libraries or any of the third party libraries below
 
 ## Code Snippets
 
+- [PROPS!](http://props.tools/) - Copy-paste customizable, theme-agnostic* custom liquid sections.
 - [freakdesign/shopify-code-snippets](https://github.com/freakdesign/Shopify-code-snippets) - Shopify Code Snippets examples and tips.
 - [vikrantnegi/shopify-code-snippets](https://github.com/vikrantnegi/shopify-code-snippets) - A compilation of code snippets for Shopify developers.
 - [gocomet/snippets](https://github.com/gocomet/snippets) - A collection of code snippets, generally for use with Shopify.

--- a/readme.md
+++ b/readme.md
@@ -235,10 +235,10 @@ You can use official Shopify libraries or any of the third party libraries below
 
 ## Code Snippets
 
-- [PROPS!](http://props.tools/) - Copy-paste customizable, theme-agnostic* custom liquid sections.
 - [freakdesign/shopify-code-snippets](https://github.com/freakdesign/Shopify-code-snippets) - Shopify Code Snippets examples and tips.
 - [vikrantnegi/shopify-code-snippets](https://github.com/vikrantnegi/shopify-code-snippets) - A compilation of code snippets for Shopify developers.
 - [gocomet/snippets](https://github.com/gocomet/snippets) - A collection of code snippets, generally for use with Shopify.
+- [PROPS!](http://props.tools/) - Copy-paste customizable, theme-agnostic* custom liquid sections.
 
 ## Developer Tools
 


### PR DESCRIPTION
Added a link to PROPS! Library for customizable liquid sections, copy-paste the code and directly to your theme files.