### PR TITLE
Add Agentprobe — free AI agent readiness scorer for Shopify stores

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,7 @@ You can use official Shopify libraries or any of the third party libraries below
 - [RequestBin](https://requestbin.net/) - It gives you a bucket to capture external requests. This is useful for seeing what the content of a [Shopify Webhook](https://shopify.dev/docs/api/webhooks) are.
 - [Hookdeck](https://hookdeck.com/) - Tool for monitoring, managing and debugging Shopify Webhooks with custom retry logic, alerts, and filtering.
 - [DeployHQ](https://www.deployhq.com/shopify) - Shopify integration in DeployHQ is a great way to streamline the development, review, and deployment of your store themes.
+- [Agentprobe](https://agentprobe.fly.dev/) - Free agentic commerce readiness scorer. Check if your Shopify store can be discovered, quoted, and purchased by AI shopping agents. Probes 13 signals (llms.txt, OpenAPI, catalog/quote/checkout APIs, payment rail declarations) and returns a 0–110 score with a CERTIFIED badge.
 
 ### Browser Extensions
 


### PR DESCRIPTION
## What this adds

**[Agentprobe](https://agentprobe.fly.dev/)** — free tool that checks whether a Shopify store can be discovered, quoted, and purchased by AI shopping agents.

## Context

AI shopping agents (from OpenAI, Perplexity, Anthropic) are increasingly routing purchase intent directly to stores. Stores without machine-readable catalogs, quote endpoints, or declared payment rails are invisible to this traffic.

Agentprobe probes any seller URL across 13 signals and returns a 0–110 score:
- llms.txt, OpenAPI spec, ai-plugin.json, MCP endpoint
- Machine-readable catalog, quote endpoint, checkout handoff
- Payment rail declarations, refund/contact metadata, fulfillment proof

Grade tiers: NOT_READY / PARTIAL / AGENT_READY / CERTIFIED

## Why it belongs in Services

It's a standalone hosted tool that Shopify developers and merchants can use to audit their store's readiness. No install required — just enter a store URL.

Example: https://agentprobe.fly.dev/?url=shopify.com