### PR TITLE
Add Ecommerce Profit Tracker PRO to Services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -272,6 +272,7 @@ You can use official Shopify libraries or any of the third party libraries below
 - [Hookdeck](https://hookdeck.com/) - Tool for monitoring, managing and debugging Shopify Webhooks with custom retry logic, alerts, and filtering.
 - [DeployHQ](https://www.deployhq.com/shopify) - Shopify integration in DeployHQ is a great way to streamline the development, review, and deployment of your store themes.
 - [Calcmatic Shopify Payment Calculator](https://calcmatic.app/calculators/ecommerce/shopify-payments) - Calculate your Shopify payment processing fees instantly.
+- [Ecommerce Profit Tracker PRO](https://whop.com/glm-643b/ecommerce-profit-tracker-pro-know-your-real-profit) - Spreadsheet-based profit tracker that calculates true net profit per Shopify order after fees, ads and COGS in Excel or Google Sheets.
 - [ShopSavvy](https://github.com/shopsavvy/shopify-shopsavvy) - Shopify app for competitor price monitoring and real-time price comparison across thousands of retailers.
 
 ### Browser Extensions


### PR DESCRIPTION
## What

Adds **Ecommerce Profit Tracker PRO** to the Developer Tools > Services section, right after Calcmatic Shopify Payment Calculator.

## Why it fits

The Services section already lists Calcmatic (a Shopify fee/profit calculator) and ShopSavvy (merchant tool). Ecommerce Profit Tracker PRO sits directly alongside them — it's a profit-and-fee tracker for Shopify merchants, sold as a one-time $19 Excel/Google Sheets workbook rather than a recurring SaaS.

For Shopify merchants who want an offline, no-subscription alternative to compute true net profit per order (after processing fees, ad spend, COGS, shipping), it complements the existing entries. Following the same precedent as Calcmatic: an external independent merchant tool, non-affiliate, single-purpose.

## Format

Followed the existing list style: `- [Name](url) - Description.`

I built this product myself. Happy to adjust wording or placement. Thanks for maintaining this list!