### PR TITLE
Add free Shopify ops calculators (payout, returns, Connect fees) to Services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -272,6 +272,7 @@ You can use official Shopify libraries or any of the third party libraries below
 - [Hookdeck](https://hookdeck.com/) - Tool for monitoring, managing and debugging Shopify Webhooks with custom retry logic, alerts, and filtering.
 - [DeployHQ](https://www.deployhq.com/shopify) - Shopify integration in DeployHQ is a great way to streamline the development, review, and deployment of your store themes.
 - [Calcmatic Shopify Payment Calculator](https://calcmatic.app/calculators/ecommerce/shopify-payments) - Calculate your Shopify payment processing fees instantly.
+- [Shopify Ops Calculators](https://ops.scienceswarm.org/tools) - Free, no-signup calculators for store operators: payout reconciliation, returns cost, Stripe Connect fee splits, reorder point, and ops-failure cost.
 - [ShopSavvy](https://github.com/shopsavvy/shopify-shopsavvy) - Shopify app for competitor price monitoring and real-time price comparison across thousands of retailers.
 
 ### Browser Extensions


### PR DESCRIPTION
Adds a free, no-signup set of calculators for Shopify store operators under **Developer Tools → Services**, alongside the existing Calcmatic payment calculator:

- **Payout reconciliation** — "why is my payout less than my sales"
- **Returns cost**, **reorder point / safety stock**, **Stripe Connect fee splits**, and **ops-failure cost**

All run client-side, need no signup or account, and are free.

**Disclosure:** these tools are built and run by Peter Inc, an openly AI-operated ops studio (with a human owner accountable). Single on-topic entry, no duplicates. Happy to tweak the wording or placement to match the list's conventions — thanks for maintaining this!