### PR TITLE
Add Shopify Markets Hreflang Evidence to Developer Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,7 @@ You can use official Shopify libraries or any of the third party libraries below
 
 - [Shopify Product CSVs](https://github.com/shopifypartners/product-csvs) - Get your Shopify development stores started with great product data.
 - [Shopify Product CSVs and Images](https://github.com/shopifypartners/shopify-product-csvs-and-images) - Get your Shopify development stores started with great product data.
+- [Shopify Markets Hreflang Evidence](https://github.com/wadimxyz/shopify-hreflang-evidence) - Read-only checker for public Shopify Markets hreflang, canonical, redirect, and coverage evidence.
 - [Shopify Schema Validator](https://podifai.com/tools/shopify-schema-validator) - Free tool to validate Shopify theme schema JSON (settings_schema.json, section schemas) with real-time error detection and fix suggestions.
 
 ## Community


### PR DESCRIPTION
## Summary

- Adds Shopify Markets Hreflang Evidence to Developer Tools > Utilities.
- The project is a read-only checker for hreflang, canonical, redirect, and observed coverage evidence on public Shopify Markets URLs.
- I maintain the linked project; this entry uses the existing list format and is intentionally factual.
- The [rendered evidence report](https://wadimxyz.github.io/shopify-hreflang-evidence/) is a documentation-only sample with no form, tracking, payment, or hosted crawl.

## Checks

- npm run lint
- npm run links
- git diff --check
