### PR TITLE
Add Review Triage Worksheet to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,7 @@ You can use official Shopify libraries or any of the third party libraries below
 
 ### Utilities
 
+- [Review Triage Worksheet](https://alfredtech2026.github.io/shopify-app-review-brief/tools/review-triage-worksheet.html?utm_source=awesome-shopify&utm_medium=resource-directory&utm_campaign=inbound-validation) - Free, open-source browser worksheet that locally sorts pasted Shopify App Store reviews into incident risk, repeated friction, pricing confusion, and feature requests.
 - [Shopify Product CSVs](https://github.com/shopifypartners/product-csvs) - Get your Shopify development stores started with great product data.
 - [Shopify Product CSVs and Images](https://github.com/shopifypartners/shopify-product-csvs-and-images) - Get your Shopify development stores started with great product data.
 


### PR DESCRIPTION
## Short pitch

Adds **Review Triage Worksheet**, a free and open-source browser utility for Shopify app teams. It turns pasted public Shopify App Store review rows into a transparent first-pass triage across incident risk, repeated friction, pricing confusion, and feature requests, then generates a Markdown draft.

The tool runs locally in the browser with no uploads, cookies, storage, analytics, external assets, or account requirement. Its heuristic rules are visible on the page, and the output is explicitly labeled not human-checked.

- Shopify-specific development/product-ops resource
- Source: https://github.com/alfredtech2026/shopify-app-review-brief
- License: MIT
- Maintained: latest release and commit are from August 2026
- One new entry, alphabetized under Developer Tools → Utilities

## Verification

- `npm run lint`
- `npm run links`
- Live tool returns HTTP 200