### PR TITLE
Add `create-shopify-firebase-app`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ You can use official Shopify libraries or any of the third party libraries below
 
 ### Shopify App Templates
 
+- [create-shopify-firebase-app](https://github.com/mksd0398/create-shopify-firebase-app) - CLI that scaffolds an embedded Shopify app on Firebase Hosting, Cloud Functions and Firestore, as an alternative to the Remix and React Router templates.
 - [Shopify Payments App Template (Remix)](https://github.com/Shopify/example-app--payments-app-template--remix) - Remix template for building Shopify apps with payments integration (Payments App API support). 🚀
 - [Shopify Credit Card Payments Template (Remix)](https://github.com/Shopify/example-app--credit-card-payments-app-template--remix) - Remix example showing Credit Card Payments integration using Shopify’s Payments API. 🏦
 - [Shopify App Template (React Router)](https://github.com/Shopify/shopify-app-template-react-router) - Template for Shopify apps using React Router for routing instead of Next.js or Remix.


### PR DESCRIPTION
Adds [create-shopify-firebase-app](https://github.com/mksd0398/create-shopify-firebase-app) under **Example Apps → Shopify App Templates**.

**Short pitch:** an MIT-licensed CLI that scaffolds an embedded Shopify app running on Firebase — Hosting for the frontend, gen-2 Cloud Functions for OAuth/API/webhooks/app-proxy, and Firestore for sessions. It is the Firebase counterpart to the official Remix and React Router templates, aimed at developers who want to stay on a free tier until they have real traffic. One command goes from nothing to a deployed, installable app.

The frontend is deliberately framework-free — Polaris web components plus App Bridge, no React and no bundler — so it sits alongside the existing React Router template rather than duplicating it. Currently on Shopify Admin API 2026-07.

Placed alphabetically at the top of the section. There are currently no Firebase entries anywhere in the list.

Checklist per contributing.md:
- One new entry in this PR
- Open source, MIT licensed
- Actively maintained (commits this week)
- Specifically a Shopify development resource
- `npm run lint` passes locally