### PR TITLE
Add multichannel-settlement to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,7 @@ You can use official Shopify libraries or any of the third party libraries below
 
 - [Shopify Product CSVs](https://github.com/shopifypartners/product-csvs) - Get your Shopify development stores started with great product data.
 - [Shopify Product CSVs and Images](https://github.com/shopifypartners/shopify-product-csvs-and-images) - Get your Shopify development stores started with great product data.
+- [multichannel-settlement](https://github.com/actorlee007-cmyk/multichannel-settlement) - Reconciles order export CSVs from Shopify and other channels; handles blank order-level fields on extra line items and unit-vs-line prices. Standard library Python, runs locally.
 
 ## Community
 


### PR DESCRIPTION
## Short pitch

A small open-source CLI that reconciles Shopify order export CSVs alongside exports from other channels a merchant sells on, and reports what actually lands in the bank after per-channel fees.

It exists because two things in the Shopify order export quietly produce wrong totals in a spreadsheet:

1. **Order-level fields are blank on extra line items.** Per Shopify's docs, "Many of the fields are left blank to indicate that multiple items were purchased on the same order." Filtering by `Financial Status` therefore keeps only the first row of a refunded multi-item order, and the remaining rows stay in the totals. The tool carries those fields down before anything is filtered.
2. **`Lineitem price` is a unit price, while some other marketplaces' equivalent column is already a line total.** The column name cannot tell you which, and getting it wrong under-reports revenue with no error shown. The tool reconciles both readings against the order total present in the export and uses whichever matches.

If it cannot find an amount column in a file, it lists that file as skipped and leaves it out rather than producing a total that looks correct.

## Criteria

- **Open source with license:** MIT
- **Maintained:** active, commits this week
- **Fits the section:** `Developer Tools > Utilities` already holds Shopify CSV resources; this is a CSV utility for the order export
- **One entry, one PR:** yes
- **Table of contents:** unchanged — no section added or removed

Repository: https://github.com/actorlee007-cmyk/multichannel-settlement

Python 3.6+, standard library only, no install, runs locally, nothing uploaded. A sample export and the exact output it produces are committed to the repo so the behaviour above can be reproduced in one command.