### PR TITLE
Add Shopify packing slip personalization snippet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,7 @@ You can use official Shopify libraries or any of the third party libraries below
 ## Code Snippets
 
 - [freakdesign/shopify-code-snippets](https://github.com/freakdesign/Shopify-code-snippets) - Shopify Code Snippets examples and tips.
+- [revertcreations/shopify-packing-slip-personalization](https://github.com/revertcreations/shopify-packing-slip-personalization) - A validated Liquid snippet for printing public line-item personalization properties on Shopify packing slips.
 - [vikrantnegi/shopify-code-snippets](https://github.com/vikrantnegi/shopify-code-snippets) - A compilation of code snippets for Shopify developers.
 - [gocomet/snippets](https://github.com/gocomet/snippets) - A collection of code snippets, generally for use with Shopify.
 - [PROPS!](http://props.tools/) - Copy-paste customizable, theme-agnostic* custom liquid sections.


### PR DESCRIPTION
Adds one MIT-licensed, maintained Shopify development resource to the Code Snippets section. The repository provides a small Liquid block for printing public line-item personalization properties on Shopify packing slips, with installation boundaries and a direct link to Shopify’s official packing-slip variable reference. The Liquid file passed Shopify’s validator before submission.

Local awesome-lint reached its repository-identity rule because this checkout is a fork; the upstream pull-request check is the authoritative lint result.